### PR TITLE
fix(preview): resolve stream i18n linked-format runtime error

### DIFF
--- a/app/markdown-next-preview/src/i18n.ts
+++ b/app/markdown-next-preview/src/i18n.ts
@@ -128,9 +128,9 @@ export const i18n = createI18n({
         stop: '停止',
         clear: '清空输出',
         securityHint:
-          '提示：API Key 仅保留在当前页面内存，不会写入本地存储。若模型不支持自定义 temperature，会自动回退到默认值请求。',
+          '提示：API Key 会保存到当前浏览器 localStorage 以便下次填写。若模型不支持自定义 temperature，会自动回退到默认值请求。',
         outputTitle: '实时渲染输出',
-        outputDescription: '使用 @markdown-next/vue 的 streaming 模式渲染逐块增量内容。',
+        outputDescription: "使用 {'@'}markdown-next/vue 的 streaming 模式渲染逐块增量内容。",
         chunkCount: 'Chunk 数',
         elapsedMs: '耗时(ms)',
         emptyState: '等待输出。先填写配置并点击“开始流式请求”。',
@@ -201,10 +201,10 @@ export const i18n = createI18n({
         stop: 'Stop',
         clear: 'Clear Output',
         securityHint:
-          'Note: API key stays in page memory only and is never persisted. If a model rejects custom temperature, the request retries with default temperature.',
+          'Note: API key is saved in browser localStorage for convenience. If a model rejects custom temperature, the request retries with default temperature.',
         outputTitle: 'Live Render Output',
         outputDescription:
-          'Renders incremental markdown blocks using @markdown-next/vue streaming mode.',
+          "Renders incremental markdown blocks using {'@'}markdown-next/vue streaming mode.",
         chunkCount: 'Chunks',
         elapsedMs: 'Elapsed(ms)',
         emptyState: 'Waiting for output. Fill the form and click "Start Stream".',

--- a/packages/vue/__tests__/e2e/worker-pool.vite7.e2e.test.ts
+++ b/packages/vue/__tests__/e2e/worker-pool.vite7.e2e.test.ts
@@ -17,6 +17,7 @@ const KNOWN_BUG_ERROR_PATTERNS = [
   'The file does not exist at',
   'document is not defined',
   '/.vite/deps/modules/parser.worker.mjs',
+  'Invalid linked format',
 ];
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
@@ -270,6 +271,21 @@ describe('vite7 worker pool e2e', () => {
       return heading?.textContent?.includes('Edge Update 8');
     });
     await page.waitForSelector('mjx-container');
+    expectNoKnownBugErrors(runtimeErrors);
+
+    await page.close();
+  });
+
+  it('renders stream demo route without i18n format errors', async () => {
+    const page = await browser.newPage();
+    const runtimeErrors = trackRuntimeErrors(page);
+
+    await page.goto(`${baseUrl}/#stream`, { waitUntil: 'networkidle' });
+    await page.waitForSelector('.stream-control-pane h2');
+    await page.waitForSelector('.stream-output-pane h2');
+
+    const streamTitle = (await page.locator('.stream-control-pane h2').first().textContent()) ?? '';
+    expect(streamTitle.trim().length).toBeGreaterThan(0);
     expectNoKnownBugErrors(runtimeErrors);
 
     await page.close();


### PR DESCRIPTION
## Summary
- fix production stream page crash caused by vue-i18n linked-format parsing on `@markdown-next/vue`
- escape `@` marker in stream i18n copy to avoid accidental linked message parsing
- align security hint text with actual behavior (API key is stored in localStorage)
- add e2e regression test that opens `/#stream` and asserts no runtime format error

## Root Cause
`vue-i18n` treats `@...` as linked-message syntax. Two stream-page messages used raw `@markdown-next/vue`, which triggers `Invalid linked format` in production runtime compilation.

## Validation
- `pnpm --filter markdown-next-preview build`
- `pnpm --filter @markdown-next/vue test`
- `pnpm test`
